### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python index.py"

--- a/.replit
+++ b/.replit
@@ -1,2 +1,0 @@
-language = "python3"
-run = "python index.py"

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ All you need to know about the library is defined inside here, even code that I 
 
 5. You're done, enjoy your bot!
 
+### Repl.it Setup (Optional)
+
+You can run this on Repl.it!
+[![Run on Repl.it](https://repl.it/badge/github/AlexFlipnote/discord_bot.py)](https://repl.it/github/AlexFlipnote/discord_bot.py)
+Make sure to setup **config.json** in the way stated above.
+
 # FAQ
 Q: I don't see my bot on my server!<br>
 A: Invite it by using this URL: https://discordapp.com/oauth2/authorize?client_id=CLIENT_ID&scope=bot<br>


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@pieromqwerty/discordbotpy).