### PR TITLE
Added support for new competing activity type and removed changing status from on_ready

### DIFF
--- a/cogs/discord.py
+++ b/cogs/discord.py
@@ -75,7 +75,7 @@ class Discord_Info(commands.Cog):
     async def server(self, ctx):
         """ Check info about current server """
         if ctx.invoked_subcommand is None:
-            findbots = sum(1 for member in ctx.guild.members if member.bot)
+            find_bots = sum(1 for member in ctx.guild.members if member.bot)
 
             embed = discord.Embed()
 
@@ -87,7 +87,7 @@ class Discord_Info(commands.Cog):
             embed.add_field(name="Server Name", value=ctx.guild.name, inline=True)
             embed.add_field(name="Server ID", value=ctx.guild.id, inline=True)
             embed.add_field(name="Members", value=ctx.guild.member_count, inline=True)
-            embed.add_field(name="Bots", value=findbots, inline=True)
+            embed.add_field(name="Bots", value=find_bots, inline=True)
             embed.add_field(name="Owner", value=ctx.guild.owner, inline=True)
             embed.add_field(name="Region", value=ctx.guild.region, inline=True)
             embed.add_field(name="Created", value=default.date(ctx.guild.created_at), inline=True)

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -64,33 +64,13 @@ class Events(commands.Cog):
 
     @commands.Cog.listener()
     async def on_ready(self):
-        """ The function that actiavtes when boot was completed """
+        """ The function that activates when boot was completed """
         if not hasattr(self.bot, 'uptime'):
             self.bot.uptime = datetime.utcnow()
 
         # Indicate that the bot has successfully booted up
         print(f'Ready: {self.bot.user} | Servers: {len(self.bot.guilds)}')
 
-        # Check if user desires to have something other than online
-        if self.config.status_type == "idle":
-            status_type = discord.Status.idle
-        elif self.config.status_type == "dnd":
-            status_type = discord.Status.dnd
-        else:
-            status_type = discord.Status.online
-
-        # Check if user desires to have a different type of playing status
-        if self.config.playing_type == "listening":
-            playing_type = 2
-        elif self.config.playing_type == "watching":
-            playing_type = 3
-        else:
-            playing_type = 0
-
-        await self.bot.change_presence(
-            activity=discord.Activity(type=playing_type, name=self.config.playing),
-            status=status_type
-        )
 
 
 def setup(bot):

--- a/config.json.example
+++ b/config.json.example
@@ -5,10 +5,11 @@
     86477779717066752
   ],
   "prefix": [
-    "!"
+    "!",
+    "?"
   ],
-  "playing": "games!",
-  "playing_type": "playing|watching|listening",
+  "activity": "games!",
+  "activity_type": "playing|watching|listening|competing",
   "status_type": "online|idle|dnd",
-  "version": "2.0.1"
+  "version": "2.0.2"
 }

--- a/config.json.example
+++ b/config.json.example
@@ -5,8 +5,7 @@
     86477779717066752
   ],
   "prefix": [
-    "!",
-    "?"
+    "!"
   ],
   "activity": "games!",
   "activity_type": "playing|watching|listening|competing",

--- a/index.py
+++ b/index.py
@@ -9,11 +9,13 @@ print("Logging in...")
 
 bot = Bot(
     command_prefix=config.prefix,
+    owner_ids = config.owners,
     prefix=config.prefix,
     command_attrs=dict(hidden=True),
     help_command=HelpFormat(),
     intents=discord.Intents(members=True)
 )
+# see more about intents here: https://discordpy.readthedocs.io/en/latest/intents.html
 
 for file in os.listdir("cogs"):
     if file.endswith(".py"):

--- a/index.py
+++ b/index.py
@@ -9,7 +9,7 @@ print("Logging in...")
 
 bot = Bot(
     command_prefix=config.prefix,
-    owner_ids = config.owners,
+    owner_ids=config.owners,
     prefix=config.prefix,
     command_attrs=dict(hidden=True),
     help_command=HelpFormat(),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-asyncio
 git+https://github.com/Rapptz/discord.py@master
+asyncio
 psutil
 pytz
 timeago==1.0.13

--- a/utils/data.py
+++ b/utils/data.py
@@ -12,19 +12,21 @@ class Bot(AutoShardedBot):
         self.prefix = prefix
 
         # Check if user desires to have something other than online
-        if config.status_type.lower() == "idle":
+        status = config.status_type.lower()
+        if status == "idle":
             status_type = discord.Status.idle
-        elif config.status_type.lower() in ("do not disturb", "dnd"):
+        elif status in ("do not disturb", "dnd"):
             status_type = discord.Status.dnd
         else:
             status_type = discord.Status.online
 
         # Check if user desires to have a different type of activity
-        if config.activity_type.lower() == "listening":
+        activity = config.activity_type.lower()
+        if activity == "listening":
             activity_type = discord.ActivityType.listening
-        elif config.activity_type.lower() == "watching":
+        elif activity == "watching":
             activity_type = discord.ActivityType.watching
-        elif config.activity_type.lower() == "competing":
+        elif activity == "competing":
             activity_type = discord.ActivityType.competing
         else:
             activity_type = discord.ActivityType.playing
@@ -47,13 +49,13 @@ class HelpFormat(DefaultHelpCommand):
             return self.context.author
 
     async def send_error_message(self, error):
-        destination = self.get_destination(no_pm = True)
+        destination = self.get_destination(no_pm=True)
         await destination.send(error)
 
     async def send_command_help(self, command):
         self.add_command_formatting(command)
         self.paginator.close_page()
-        await self.send_pages(no_pm = True)
+        await self.send_pages(no_pm=True)
 
     async def send_pages(self, no_pm: bool = False):
         try:
@@ -63,9 +65,9 @@ class HelpFormat(DefaultHelpCommand):
             pass
 
         try:
-            destination = self.get_destination(no_pm = no_pm)
+            destination = self.get_destination(no_pm=no_pm)
             for page in self.paginator.pages:
                 await destination.send(page)
         except discord.Forbidden:
-            destination = self.get_destination(no_pm = True)
+            destination = self.get_destination(no_pm=True)
             await destination.send("Couldn't send help to you due to blocked DMs...")


### PR DESCRIPTION

New activity type can be found [here](https://discordpy.readthedocs.io/en/latest/api.html#discord.ActivityType.competing)

About changing status in on_ready: this is not recommended and can cause issues. See more in the `?tag orp` tag on the [discord.py server](https://discord.gg/dpy) I moved it to data.py to use the `activity` and `status` kwargs to do the same thing.

Added owner ids from config as the owners for the bot.

Changed playing and playing_type to activity and activity_type because this confused some people.

Also added a comment in index.py about intents so users can learn more about them.
