### PR TITLE
Disabled Python Buffered output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM python:3.10-alpine
 LABEL maintainer="AlexFlipnote <root@alexflipnote.dev>"
 
-LABEL build_date="2021-10-17"
+LABEL build_date="2022-04-25"
 RUN apk update && apk upgrade
 RUN apk add --no-cache git make build-base linux-headers
 WORKDIR /discord_bot
 COPY . .
 RUN pip install --no-cache-dir -r requirements.txt
 
-CMD ["python", "index.py"]
+CMD ["python", "-u", "index.py"]


### PR DESCRIPTION
Added the ``-u`` switch to disable Python's buffered output. Wasn't printing statements in the logs for the Docker version of the bot.