### PR TITLE
Fix different activity types not working at all

### DIFF
--- a/cogs/events.py
+++ b/cogs/events.py
@@ -74,7 +74,7 @@ class Events(commands.Cog):
         activity_type = {"listening": 2, "watching": 3, "competing": 5}
 
         await self.bot.change_presence(
-            activity=discord.Game(
+            activity=discord.Activity(
                 type=activity_type.get(activity, 0),
                 name=self.bot.config.discord_activity_name
             ),


### PR DESCRIPTION
Having this as `discord.Game` forces the presence to "playing" and ignores the activity type you give to it.